### PR TITLE
Add simple MLFlow integration

### DIFF
--- a/kauldron/train/contrib/mlflow_metric_writer.py
+++ b/kauldron/train/contrib/mlflow_metric_writer.py
@@ -31,7 +31,7 @@ class MLFlowMetricWriter(KDMetricWriter):
     def get_config():
         return kd.train.Trainer(
             ...
-            writer=mlflow_tracker.MLFlowWriter(pass_to_default_writer=False),
+            writer=mlflow_metric_writer.MLFlowMetricWriter(pass_to_default_writer=False),
             log_metrics_every = 5,
             log_summaries_every = 1000,
             ...


### PR DESCRIPTION
This PR adds a simple way to integrate MLFlow experiment tracking to kauldron.

This example can be used to also integrate other services.

Metric logging:

![image](https://github.com/user-attachments/assets/0cb0d2b4-cf7a-493a-a74e-458c97c99be1)

Artifact logging:

![image](https://github.com/user-attachments/assets/d4653f77-a8ca-4720-baac-50f9a7399bc3)
