### PR TITLE
fix missing hash sign for comment breaking kauldron/main.py

### DIFF
--- a/kauldron/main.py
+++ b/kauldron/main.py
@@ -26,7 +26,7 @@ from etils import epy
 from etils.epy import _multiprocess
 import jax
 
-Force CUDA symbol resolution by jax before tensorflow gets initialized.
+# Force CUDA symbol resolution by jax before tensorflow gets initialized.
 jax.devices()
 
 import tensorflow as tf


### PR DESCRIPTION
seems like this might have been removed by mistake recently in https://github.com/google-research/kauldron/commit/ab0427d44bce6cb6d1e17f6db307ae86e5b07568

